### PR TITLE
move scuttlebot/lib/seal funcs into ssb-keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,23 @@ var hash = ssbkeys.hash(new Buffer('deadbeef', 'hex'))
 ssbkeys.isHash(hash) // => true
 
 var sig = ssbkeys.sign(k, hash)
-ssbkeys.verify(k.public, sig, hash)
+ssbkeys.verify(k.public, sig, hash) // => true
 
-ssbkeys.hmac(new Buffer('deadbeef', 'hex'), k.private) // => String
+var secret = new Buffer('deadbeef', 'hex')
+ssbkeys.hmac(secret, k.private) // => String
+
+var obj = ssbkeys.signObj(k, { foo: 'bar' })
+console.log(obj) /* => {
+  foo: 'bar',
+  signature: ...
+} */
+ssbkeys.verifyObj(k, obj) // => true
+
+var secret = new Buffer('deadbeef', 'hex')
+var obj = ssbkeys.signObjHmac(secret, { foo: 'bar' })
+console.log(obj) /* => {
+  foo: 'bar',
+  hmac: ...
+} */
+ssbkeys.verifyObjHmac(secret, obj) // => true
 ```


### PR DESCRIPTION
Since there was a naming collision, I chose the names signObj, verifyObj, signObjHmac, and verifyObjHmac
