### PR TITLE
tracking PR: add nacl crypto

### DIFF
--- a/browser-sodium.js
+++ b/browser-sodium.js
@@ -1,0 +1,35 @@
+
+var sodium = require('libsodium-wrappers')
+var crypto = require('crypto')
+
+var B = Buffer
+
+function Ui8 (b) {
+  return new Uint8Array(b)
+}
+
+module.exports = {
+
+  curves: ['ed25519'],
+
+  generate: function () {
+    var keys = sodium.crypto_sign_keypair()
+    return {
+      curve: 'ed25519',
+      public: B(keys.publicKey),
+
+      //so that this works with either sodium
+      //or libsodium-wrappers (in browser)
+      private: B(keys.privateKey || keys.secretKey)
+    }
+  },
+
+  sign: function (private, message) {
+    return B(sodium.crypto_sign_detached(Ui8(message), Ui8(private)))
+  },
+
+  verify: function (public, sig, message) {
+    return sodium.crypto_sign_verify_detached(Ui8(sig), Ui8(message), Ui8(public))
+  }
+
+}

--- a/eccjs.js
+++ b/eccjs.js
@@ -1,13 +1,22 @@
 
 
-var eccjs = require('eccjs')
+var ecc = require('eccjs')
+var crypto = require('crypto')
+
+var curve = ecc.curves.k256
 
 module.exports = {
 
   curves: ['k256'],
 
   generate: function () {
-    var keys = ecc.generate(crypto.randomBytes(32))
+    //we use eccjs.restore here, instead of eccjs.generate
+    //because we trust node's random generator much more than
+    //sjcl's (via crypto-browserify's polyfil this uses
+    //webcrypto's random generator in the browser)
+
+    var keys = ecc.restore(curve, crypto.randomBytes(32))
+
     return {
       curve: 'k256',
       public: keys.public,
@@ -16,11 +25,15 @@ module.exports = {
   },
 
   sign: function (private, message) {
-    return ecc.sign(private, message)
+    return ecc.sign(curve, private, message)
   },
 
   verify: function (public, sig, message) {
-    return ecc.verify(public, sig, message)
+    return ecc.verify(curve, public, sig, message)
+  },
+
+  restore: function (seed) {
+    return ecc.restore(curve, seed)
   }
 
 }

--- a/eccjs.js
+++ b/eccjs.js
@@ -1,0 +1,26 @@
+
+
+var eccjs = require('eccjs')
+
+module.exports = {
+
+  curves: ['k256'],
+
+  generate: function () {
+    var keys = ecc.generate(crypto.randomBytes(32))
+    return {
+      curve: 'k256',
+      public: keys.public,
+      private: keys.private
+    }
+  },
+
+  sign: function (private, message) {
+    return ecc.sign(private, message)
+  },
+
+  verify: function (public, sig, message) {
+    return ecc.verify(public, sig, message)
+  }
+
+}

--- a/eccjs.js
+++ b/eccjs.js
@@ -9,13 +9,13 @@ module.exports = {
 
   curves: ['k256'],
 
-  generate: function () {
+  generate: function (seed) {
     //we use eccjs.restore here, instead of eccjs.generate
     //because we trust node's random generator much more than
     //sjcl's (via crypto-browserify's polyfil this uses
     //webcrypto's random generator in the browser)
 
-    var keys = ecc.restore(curve, crypto.randomBytes(32))
+    var keys = ecc.restore(curve, seed || crypto.randomBytes(32))
 
     return {
       curve: 'k256',

--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ exports.loadOrCreateSync = function (namefile) {
 // DIGITAL SIGNATURES
 
 var curves = {
-  ed25519 : require('./browser-sodium'),
+  ed25519 : require('./sodium'),
   k256    : ecc //LEGACY
 }
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "url": "git://github.com/ssbc/ssb-crypto.git"
   },
   "dependencies": {
-    "eccjs": "git://github.com/dominictarr/eccjs.git#586f6d47507184a2efe84684ed0a30605cbc43a5",
     "blake2s": "~1.0.0",
-    "mkdirp": "~0.5.0",
-    "hmac": "~1.0.1",
     "deep-equal": "~0.2.1",
-    "ecma-nacl": "~2.0.1"
+    "eccjs": "git://github.com/dominictarr/eccjs.git#586f6d47507184a2efe84684ed0a30605cbc43a5",
+    "hmac": "~1.0.1",
+    "libsodium-wrappers": "^0.2.8",
+    "mkdirp": "~0.5.0",
+    "sodium": "^1.0.17"
   },
   "devDependencies": {
     "tape": "~3.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "blake2s": "~1.0.0",
     "mkdirp": "~0.5.0",
     "hmac": "~1.0.1",
-    "deep-equal": "~0.2.1"
+    "deep-equal": "~0.2.1",
+    "ecma-nacl": "~2.0.1"
   },
   "devDependencies": {
     "tape": "~3.0.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "devDependencies": {
     "tape": "~3.0.0"
   },
+  "browser": {
+    "./sodium": "./browser-sodium"
+  },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"
   },

--- a/sodium.js
+++ b/sodium.js
@@ -6,8 +6,8 @@ module.exports = {
 
   curves: ['ed25519'],
 
-  generate: function () {
-    var keys = sodium.crypto_sign_keypair(crypto.randomBytes(32))
+  generate: function (seed) {
+    var keys = sodium.crypto_sign_seed_keypair(seed || crypto.randomBytes(32))
     return {
       curve: 'ed25519',
       public: keys.publicKey,

--- a/sodium.js
+++ b/sodium.js
@@ -1,0 +1,29 @@
+
+var sodium = require('sodium').api
+var crypto = require('crypto')
+
+module.exports = {
+
+  curves: ['ed25519'],
+
+  generate: function () {
+    var keys = sodium.crypto_sign_keypair(crypto.randomBytes(32))
+    return {
+      curve: 'ed25519',
+      public: keys.publicKey,
+
+      //so that this works with either sodium
+      //or libsodium-wrappers (in browser)
+      private: keys.privateKey || keys.secretKey
+    }
+  },
+
+  sign: function (private, message) {
+    return sodium.crypto_sign_detached(message, private)
+  },
+
+  verify: function (public, sig, message) {
+    return sodium.crypto_sign_verify_detached(sig, message, public)
+  }
+
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var tape = require('tape')
 var ssbkeys = require('../')
-
+var crypto = require('crypto')
 var path = require('path').join(__dirname, 'keyfile')
 
 tape('create and load async', function (t) {
@@ -121,4 +121,26 @@ tape('create and load sync, legacy', function (t) {
   t.end()
 })
 
+tape('seeded keys, ed25519', function (t) {
 
+  var seed = crypto.randomBytes(32)
+  var k1 = ssbkeys.generate('ed25519', seed)
+  var k2 = ssbkeys.generate('ed25519', seed)
+
+  t.deepEqual(k1, k2)
+
+  t.end()
+
+})
+
+tape('seeded keys, k256', function (t) {
+
+  var seed = crypto.randomBytes(32)
+  var k1 = ssbkeys.generate('k256', seed)
+  var k2 = ssbkeys.generate('k256', seed)
+
+  t.deepEqual(k1, k2)
+
+  t.end()
+
+})

--- a/test/index.js
+++ b/test/index.js
@@ -26,3 +26,18 @@ tape('create and load sync', function (t) {
   t.equal(k1.public.toString('hex'), k2.public.toString('hex'))
   t.end()
 })
+
+
+tape('sign and verify', function (t) {
+
+  var keys = ssbkeys.generate()
+  var msg = ssbkeys.hash("HELLO THERE?")
+  var sig = ssbkeys.sign(keys, msg)
+  console.log('public', keys.public)
+  console.log('sig', sig)
+  t.ok(sig)
+  t.ok(ssbkeys.verify(keys, sig, msg))
+
+  t.end()
+
+})

--- a/test/index.js
+++ b/test/index.js
@@ -72,3 +72,53 @@ tape('sign and verify a javascript object', function (t) {
   t.end()
 
 })
+
+tape('test legacy curve: k256', function (t) {
+  var keys = ssbkeys.generate('k256')
+
+  var msg = ssbkeys.hash("LEGACY SYSTEMS")
+  var sig = ssbkeys.sign(keys, msg)
+
+  console.log('public', keys.public)
+  console.log('sig', sig)
+
+  t.ok(sig)
+  t.equal(ssbkeys.getTag(sig), 'blake2s.k256')
+  t.ok(ssbkeys.verify(keys, sig, msg))
+
+  t.end()
+})
+
+tape('create and load async, legacy', function (t) {
+  try { require('fs').unlinkSync(path) } catch(e) {}
+  ssbkeys.create(path, 'k256', function(err, k1) {
+    if (err) throw err
+    ssbkeys.load(path, function(err, k2) {
+      if (err) throw err
+
+      t.equal(k2.curve, 'k256')
+      t.equal(k1.id, k2.id)
+      t.equal(k1.private, k2.private)
+      t.equal(k1.public, k2.public)
+
+      t.end()
+    })
+  })
+})
+
+tape('create and load sync, legacy', function (t) {
+  try { require('fs').unlinkSync(path) } catch(e) {}
+  var k1 = ssbkeys.createSync(path, 'k256', true)
+  var k2 = ssbkeys.loadSync(path)
+
+  console.log(k2)
+
+  t.equal(k2.curve, 'k256')
+  t.equal(k1.id, k2.id)
+  t.equal(k1.private, k2.private)
+  t.equal(k1.public, k2.public)
+
+  t.end()
+})
+
+

--- a/test/index.js
+++ b/test/index.js
@@ -36,8 +36,39 @@ tape('sign and verify', function (t) {
   console.log('public', keys.public)
   console.log('sig', sig)
   t.ok(sig)
+  t.equal(ssbkeys.getTag(sig), 'blake2s.ed25519')
   t.ok(ssbkeys.verify(keys, sig, msg))
 
+  t.end()
+
+})
+
+tape('sign and verify, call with keys directly', function (t) {
+
+  var keys = ssbkeys.generate()
+  var msg = ssbkeys.hash("HELLO THERE?")
+  var sig = ssbkeys.sign(keys.private, msg)
+  console.log('public', keys.public)
+  console.log('sig', sig)
+  t.ok(sig)
+  t.equal(ssbkeys.getTag(sig), 'blake2s.ed25519')
+  t.ok(ssbkeys.verify(keys.public, sig, msg))
+
+  t.end()
+
+})
+
+tape('sign and verify a javascript object', function (t) {
+
+  var obj = require('../package.json')
+
+  console.log(obj)
+
+  var keys = ssbkeys.generate()
+  var sig = ssbkeys.signObj(keys.private, obj)
+  console.log(sig)
+  t.ok(sig)
+  t.ok(ssbkeys.verifyObj(keys, sig, obj))
   t.end()
 
 })


### PR DESCRIPTION
This adds [ed25519](http://ed25519.cr.yp.to/) via nacl.
It's at least twice as fast as k256 from sjcl, and doesn't have side-channel leaks...

Side channels (when you gain information about the key by examining, eg, how other software runs on the same computer... is probably a big risk in JS crypto, because it would be pretty easy to get more js running on the same computer...)

Also, this makes https://github.com/ssbc/scuttlebot/pull/192 take only 5 seconds!!!


Another benefit is that the ed25519 public key is only 32 bytes long (same size as a blake2s hash) so we can just put it in every message instead of looking up, which could make the validation algorithm simpler too!