### PR TITLE
Sigil support

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -145,10 +145,10 @@ tape('seeded keys, k256', function (t) {
 
 })
 
-tape('ed25519 id === pubkey', function (t) {
+tape('ed25519 id === "@" ++ pubkey', function (t) {
 
   var keys = ssbkeys.generate('ed25519')
-  t.equal(keys.id, keys.public)
+  t.equal(keys.id, '@' + keys.public)
 
   t.end()
 


### PR DESCRIPTION
Update to use link sigils.

Still figuring out how deep the changes need to be here. Currently, this PR affects key-generation by prepending an `@` to the `id` of a key object, and leaving `public` and `private` alone.