### PR TITLE
Remove logging of keys to stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,6 @@ function reconstructKeys(keyfile) {
   //if the key is in JSON format, we are good.
   try {
     var keys = JSON.parse(private)
-    console.log(keys)
     if(!hasSigil(keys.id)) keys.id = '@' + keys.public
     return keys
   } catch (_) {}


### PR DESCRIPTION
!! I discovered this after I installed the latest patchwork from npm; it dumped my private key into bash during startup.