### PR TITLE
make eccjs a devdep

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var deepEqual  = require('deep-equal')
 var crypto     = require('crypto')
 var createHmac = require('hmac')
 
-var ecc        = require('./eccjs')
 var sodium     = require('chloride')
 var ssbref     = require('ssb-ref')
 
@@ -132,6 +131,8 @@ function reconstructKeys(keyfile) {
   if(curve !== 'k256')
     throw new Error('expected legacy curve (k256) but found:' + curve)
 
+  var ecc = require('./eccjs')
+
   return keysToJSON(ecc.restore(toBuffer(private)), 'k256')
 }
 
@@ -202,10 +203,10 @@ exports.loadOrCreateSync = function (namefile) {
 
 // DIGITAL SIGNATURES
 
-var curves = {
-  ed25519 : require('./sodium'),
-  k256    : ecc //LEGACY
-}
+var curves = {}
+curves.ed25519 = require('./sodium')
+try { curves.k256 = require('./eccjs') }
+catch (_) {}
 
 function getCurve(keys) {
   var curve = keys.curve
@@ -309,3 +310,5 @@ exports.unbox = function (boxed, keys) {
   var msg = pb.multibox_open(boxed, sk)
   if(msg) return JSON.parse(''+msg)
 }
+
+

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "blake2s": "~1.0.0",
     "chloride": "^2.0.1",
     "deep-equal": "~0.2.1",
-    "eccjs": "git://github.com/dominictarr/eccjs.git#586f6d47507184a2efe84684ed0a30605cbc43a5",
     "hmac": "~1.0.1",
     "mkdirp": "~0.5.0",
     "private-box": "~0.0.3",
     "ssb-ref": "^2.0.0"
   },
   "devDependencies": {
+    "eccjs": "git://github.com/dominictarr/eccjs.git#586f6d47507184a2efe84684ed0a30605cbc43a5",
     "tape": "^3.0.3"
   },
   "scripts": {
@@ -26,3 +26,4 @@
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT"
 }
+


### PR DESCRIPTION
this makes eccjs into a devdep only. I wanted to leave it in the tests, so that we still have the idea of a switchable signature. but, since we don't want to use sjcl, we can drop it, and that will resolve this issue: https://github.com/ssbc/ssb-keys/issues/21