### PR TITLE
repair the fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,12 @@ function clone (obj) {
 }
 
 function hash (data, enc) {
-  return crypto.createHash('sha256').update(data,enc).digest('base64')+'.sha256'
+  data = (
+    'string' === typeof data && enc == null
+  ? new Buffer(data, 'binary')
+  : new Buffer(data, enc)
+  )
+  return crypto.createHash('sha256').update(data).digest('base64')+'.sha256'
 }
 
 var isLink = ssbref.isLink

--- a/test/weird.js
+++ b/test/weird.js
@@ -1,0 +1,30 @@
+var expected = "lFluepOmDxEUcZWlLfz0rHU61xLQYxknAEd6z4un8P8=.sha256"
+var msg = {
+  "previous": "%VBfEJjeNUlxLuK0eyRzVha3TLu5PPWLwsvGgnmAdPas=.sha256",
+  "author": "@/02iw6SFEPIHl8nMkYSwcCgRWxiG6VP547Wcp1NW8Bo=.ed25519",
+  "sequence": 2888,
+  "timestamp": 1457679971682,
+  "hash": "sha256",
+  "content": {
+    "type": "post",
+    "text": "oh no\n\nhttps://medium.com/making-instapaper/bookmarklets-are-dead-d470d4bbb626\n\n> The ultimate catch-22 of the new Content Security Policy wording is that it’s intended to benefit the users, by providing additional security from hypothetical malicious add-ons on websites that enforce a Content Security Policy. In the end the bookmarklet has been relegated obsolete by the change, a casualty of one clause in one section of one web specification, and end-users and developers are the ones who will mourn its demise. The path to hell is paved with good intentions.\n\n> I’d probably try to do more about it, but I’m too busy rewriting Instapaper’s bookmarklet into extensions for every major browser.\n\nhttps://www.youtube.com/watch?v=n5diMImYIIA",
+    "root": "%VBfEJjeNUlxLuK0eyRzVha3TLu5PPWLwsvGgnmAdPas=.sha256",
+    "branch": "%VBfEJjeNUlxLuK0eyRzVha3TLu5PPWLwsvGgnmAdPas=.sha256",
+    "channel": "javascript"
+  },
+  "signature": "Pv+LWJumKE8nIOfsZxgMcg/EcR/tZeJShmiVIGizERuiAMzwzTTjg78r+InmJopJwMogEG7/W3FLTnH/EOzLCg==.sig.ed25519"
+}
+
+
+var tape = require('tape')
+var ssbKeys = require('../')
+
+tape('test that the legacy code is as expected', function (t) {
+  var actual = ssbKeys.hash(JSON.stringify(msg, null, 2))
+  t.equal(actual, expected)
+  t.end()
+})
+
+
+
+


### PR DESCRIPTION
This will fix the fork that @wanderer found. https://github.com/ssbc/patchwork/issues/343#issuecomment-201381664

Turns out there are lots of messages that hash wrong, but we only recently discovered this, because the default behavior only changed in node@6, which so far only dust has used,
(actually, node@6 isn't even an official version yet!)

This change will make it hash consistently in node@6, as it did in node@<6

I think this should be a discussion PR for now, if @wanderer can downgrade to node@5, and we can figure out how to upgrade to a new hash/encoding that doesn't have this unfortunate bug.