### PR TITLE
hack to make base64 decoding work on electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,12 +59,26 @@ function hasSigil (s) {
 
 function empty(v) { return !!v }
 
+//crazy hack to make electron not crash
+function base64ToBuffer(s) {
+  var l = s.length * 6 / 8
+  if(s[s.length - 2] == '=')
+    l = l - 2
+  else
+  if(s[s.length - 1] == '=')
+    l = l - 1
+
+  var b = new Buffer(l)
+  b.write(s, 'base64')
+  return b
+}
+
 function toBuffer(buf) {
   if(buf == null) return buf
   if(Buffer.isBuffer(buf)) throw new Error('already a buffer')
   var i = buf.indexOf('.')
   var start = (hasSigil(buf)) ? 1 : 0
-  return new Buffer(buf.substring(start, ~i ? i : buf.length), 'base64')
+  return base64ToBuffer(buf.substring(start, ~i ? i : buf.length))
 }
 
 function toUint8(buf) {


### PR DESCRIPTION
this works around a very weird electron bug.
https://github.com/electron/electron/issues/5544

just a patch