### PR TITLE
Remove unused dependency ssb-ref

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var deepEqual  = require('deep-equal')
 
 var sodium     = require('chloride')
-var ssbref     = require('ssb-ref')
 
 var pb         = require('private-box')
 
@@ -22,9 +21,6 @@ function clone (obj) {
   }
   return _obj
 }
-
-var isLink = ssbref.isLink
-var isFeedId = ssbref.isFeedId
 
 var hmac = sodium.crypto_auth
 
@@ -166,8 +162,3 @@ exports.unbox = function (boxed, keys) {
   var msg = pb.multibox_open(boxed, sk)
   if(msg) return JSON.parse(''+msg)
 }
-
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "deep-equal": "~0.2.1",
     "hmac": "~1.0.1",
     "mkdirp": "~0.5.0",
-    "private-box": "^0.2.1",
-    "ssb-ref": "^2.0.0"
+    "private-box": "^0.2.1"
   },
   "devDependencies": {
     "tape": "^3.0.3"


### PR DESCRIPTION
I was going to use ssb-keys for a personal project, and had a read through the code. Can I depend on the package, or should I duplicate the API myself? I mean, given that the api of this package seems pretty complete, I'd say yes, but it's still branded as ssb-*