### PR TITLE
Avoid reserved keywords in sodium.js

### DIFF
--- a/sodium.js
+++ b/sodium.js
@@ -19,12 +19,12 @@ module.exports = {
     }
   },
 
-  sign: function (private, message) {
-    return sodium.crypto_sign_detached(message, private)
+  sign: function (privateKey, message) {
+    return sodium.crypto_sign_detached(message, privateKey)
   },
 
-  verify: function (public, sig, message) {
-    return sodium.crypto_sign_verify_detached(sig, message, public)
+  verify: function (publicKey, sig, message) {
+    return sodium.crypto_sign_verify_detached(sig, message, publicKey)
   }
 
 }


### PR DESCRIPTION
To support environments like React Native's packager, which checks for strict mode, we need to avoid keywords like `private` or `public`.