### PR TITLE
Fix storage.js fallback logic to local-storage

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -21,7 +21,7 @@ function toFile (filename) {
 
 module.exports = function (generate) {
 
-  if(!fs || !fs.readFileSync)
+  if(!fs || !fs.readFile)
     return require('./local-storage')(generate)
 
   var exports = {}


### PR DESCRIPTION
`fs.readFileSync` is not available in https://www.npmjs.com/package/level-filesystem which is what React Native uses when shimming `fs` (because it cannot support sync APIs). I figured that this line of code is checking (1) whether `fs` is available and (2) whether `fs` is actually a filesystem API. It seems for purpose (2) that `readFile` is enough. Or is there a reason for `readFileSync`?

With these changes, an `fs` object missing `readFileSync` would still work as long as `loadSync` is avoided and `load` is used instead.