### PR TITLE
Use number literals that are valid in strict mode

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -100,7 +100,7 @@ module.exports = function (generate) {
     var keyfile = constructKeys(keys, legacy)
     mkdirp(path.dirname(filename), function (err) {
       if(err) return cb(err)
-      fs.writeFile(filename, keyfile, {mode: 0400}, function(err) {
+      fs.writeFile(filename, keyfile, {mode: 400}, function(err) {
         if (err) return cb(err)
         cb(null, keys)
       })
@@ -112,7 +112,7 @@ module.exports = function (generate) {
     var keys = generate(curve)
     var keyfile = constructKeys(keys, legacy)
     mkdirp.sync(path.dirname(filename))
-    fs.writeFileSync(filename, keyfile, {mode: 0400})
+    fs.writeFileSync(filename, keyfile, {mode: 400})
     return keys
   }
 


### PR DESCRIPTION
I understand that `0400` resembles the respective unix permissions code, but such literal is invalid under strict mode, according to the spec: http://www.ecma-international.org/ecma-262/6.0/#sec-additional-syntax-numeric-literals

In React Native, strict mode is always enabled (as far as I know), so with `0400` we cannot run this script, so I'm modifying it to `400`.