### PR TITLE
prevent clobbering existing keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tape": "^3.0.3"
   },
   "scripts": {
-    "test": "tape test/"
+    "test": "tape test/*"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT"

--- a/storage.js
+++ b/storage.js
@@ -30,7 +30,7 @@ module.exports = function (generate) {
   //(DE)SERIALIZE KEYS
 
   function constructKeys(keys, legacy) {
-    if(!keys) throw new Error('*must* pass in keys') 
+    if(!keys) throw new Error('*must* pass in keys')
 
     return [
     '# this is your SECRET name.',
@@ -89,7 +89,7 @@ module.exports = function (generate) {
     var keyfile = constructKeys(keys, legacy)
     mkdirp(path.dirname(filename), function (err) {
       if(err) return cb(err)
-      fs.writeFile(filename, keyfile, {mode: 0x100}, function(err) {
+      fs.writeFile(filename, keyfile, {mode: 0x100, flag: 'wx'}, function(err) {
         if (err) return cb(err)
         cb(null, keys)
       })
@@ -101,7 +101,7 @@ module.exports = function (generate) {
     var keys = generate(curve)
     var keyfile = constructKeys(keys, legacy)
     mkdirp.sync(path.dirname(filename))
-    fs.writeFileSync(filename, keyfile, {mode: 0x100})
+    fs.writeFileSync(filename, keyfile, {mode: 0x100, flag: 'wx'})
     return keys
   }
 

--- a/test/fs.js
+++ b/test/fs.js
@@ -30,3 +30,16 @@ tape('create and load presigil-legacy', function (t) {
 
 })
 
+tape('prevent clobbering existing keys', function (t) {
+
+  fs.writeFileSync(path, 'this file intentionally left blank', 'utf8')
+  t.throws(function () {
+    ssbkeys.createSync(path)
+  })
+  ssbkeys.create(path, function (err) {
+    t.ok(err)
+    fs.unlinkSync(path)
+    t.end()
+  })
+
+})


### PR DESCRIPTION
this seems like a very reasonable default for a function that deals with keyfile generation

also threw in a commit that actually runs all the tests in the `/tests` directory upon `npm run test`

fixes #44 