### PR TITLE
Decrypt in `try...catch` block

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,10 +167,10 @@ exports.unboxBody = function (boxed, key) {
 
 exports.unbox = function (boxed, keys) {
   boxed = u.toBuffer(boxed)
-  var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
 
-  var msg = pb.multibox_open(boxed, sk)
   try {
+    var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
+    var msg = pb.multibox_open(boxed, sk)
     return JSON.parse(''+msg)
   } catch (_) { }
   return

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -1,5 +1,3 @@
-
-
 var tape = require('tape')
 var ssbkeys = require('../')
 
@@ -12,5 +10,15 @@ tape('box, unbox', function (t) {
   console.log('boxed')
   var msg = ssbkeys.unbox(boxed, alice.private)
   t.deepEqual(msg, {okay: true})
+  t.end()
+})
+
+tape('return undefined for invalid content', function (t) {
+
+  var alice = ssbkeys.generate()
+  var bob = ssbkeys.generate()
+
+  var msg = ssbkeys.unbox('this is invalid content', alice.private)
+  t.equal(msg, undefined)
   t.end()
 })


### PR DESCRIPTION
This resolves and issue where non-encrypted strings passed to `unbox()` throw an uncaught exception.