### PR TITLE
Export function to convert from ed25519 secret to curve25519 secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ with [private-box](https://github.com/auditdrivencrypto/private-box)
 decrypt a message encrypted with `box`. If the `boxed` successfully decrypted,
 the parsed JSON is returned, if not, `undefined` is returned.
 
+### ssbSecretKeyToPrivateBoxSecret(keys)
+
+Convert from the ed25519 secret key (ssb secret key type) to the curve25519 key type that is used by `private-box`.
+
 ### LICENSE
 
 MIT

--- a/index.js
+++ b/index.js
@@ -150,9 +150,15 @@ exports.box = function (msg, recipients) {
   return pb.multibox(msg, recipients).toString('base64')+'.box'
 }
 
+function ssbSecretKeyToPrivateBoxSecret (keys) {
+  return sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
+}
+
+exports.ssbSecretKeyToPrivateBoxSecret = ssbSecretKeyToPrivateBoxSecret
+
 exports.unboxKey = function (boxed, keys) {
   boxed = u.toBuffer(boxed)
-  var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
+  var sk = ssbSecretKeyToPrivateBoxSecret(keys)
   return pb.multibox_open_key(boxed, sk)
 }
 
@@ -170,7 +176,7 @@ exports.unbox = function (boxed, keys) {
   boxed = u.toBuffer(boxed)
 
   try {
-    var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
+    var sk = ssbSecretKeyToPrivateBoxSecret(keys)
     var msg = pb.multibox_open(boxed, sk)
     return JSON.parse(''+msg)
   } catch (_) { }


### PR DESCRIPTION
This would be useful for my work in the Rusty Sunrise Choir.

If `ssb-keys` can do the conversion between key types then I can just pass down the correct key to my rust code.