### PR TITLE
id property is public key regardless of curve

### DIFF
--- a/util.js
+++ b/util.js
@@ -27,7 +27,7 @@ exports.keysToJSON = function keysToJSON(keys, curve) {
     curve: curve,
     public: pub,
     private: keys.private ? tag(keys.private, curve) : undefined,
-    id: '@'+(curve === 'ed25519' ? pub : exports.hash(pub))
+    id: '@' + pub
   }
 }
 


### PR DESCRIPTION
This is a minor edit for clarity and should not give any change in behaviour of ssb-keys as it is now. 

For context see %rN1jBwjg3Zhz9qnEoj9gcx//uwKaKQzArVkwMUUiUtg=.sha256