### PR TITLE
increase max private-box recipients to 15

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,8 @@ exports.verifyObj = function (keys, hmac_key, obj) {
   return verify(keys, sig, b)
 }
 
+var MAX_PRIVATEBOX_RECIPIENTS = 15
+
 exports.box = function (msg, recipients) {
   msg = new Buffer(JSON.stringify(msg))
 
@@ -147,20 +149,20 @@ exports.box = function (msg, recipients) {
     return sodium.crypto_sign_ed25519_pk_to_curve25519(u.toBuffer(keys.public || keys))
   })
 
-  return pb.multibox(msg, recipients).toString('base64')+'.box'
+  return pb.multibox(msg, recipients, MAX_PRIVATEBOX_RECIPIENTS).toString('base64')+'.box'
 }
 
 exports.unboxKey = function (boxed, keys) {
   boxed = u.toBuffer(boxed)
   var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
-  return pb.multibox_open_key(boxed, sk)
+  return pb.multibox_open_key(boxed, sk, MAX_PRIVATEBOX_RECIPIENTS)
 }
 
 exports.unboxBody = function (boxed, key) {
   if(!key) return null
   boxed = u.toBuffer(boxed)
   key = u.toBuffer(key)
-  var msg = pb.multibox_open_body(boxed, key)
+  var msg = pb.multibox_open_body(boxed, key, MAX_PRIVATEBOX_RECIPIENTS)
   try {
     return JSON.parse(''+msg)
   } catch (_) { }
@@ -171,7 +173,7 @@ exports.unbox = function (boxed, keys) {
 
   try {
     var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
-    var msg = pb.multibox_open(boxed, sk)
+    var msg = pb.multibox_open(boxed, sk, MAX_PRIVATEBOX_RECIPIENTS)
     return JSON.parse(''+msg)
   } catch (_) { }
   return


### PR DESCRIPTION
although private groups will solve this better, private groups are always coming soon and have yet to come, so i think we should make private messages more palatable for real-life usage by increasing the max recipients for private-box.

concrete use case: in the last couple weeks i've created or been part of 3 (too many) private threads with more than 7 people, so either someone is left out or two threads are created (but then you miss out on the other half).

i picked 15 as a new arbitrary number to replace the old arbitrary number 7. open to other suggestions, i just want at least something between 10 and 20, maybe 12.

if accepted, this will certainly also be an interesting (mild) case of a soft fork. :smiley_cat: 

see also:

- [%ODn6QDxWApNTnvxW7lQnHff6/M5Jt+2J8AQmkutPOWo=.sha256](https://viewer.scuttlebot.io/%25ODn6QDxWApNTnvxW7lQnHff6%2FM5Jt%2B2J8AQmkutPOWo%3D.sha256)