### PR TITLE
adding missing docs but needs more work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ ssbkeys.verifyObj(k, hmac_key, obj) // => true
 
 ## api
 
+### hash (data, encoding)
+Returns the sha256 hash of a given data. If encoding is not provided then it is assumed to be _binary_.
+
+### getTag (string)
+The SSB IDs contain a tag at the end. This function returns it. So if you have a string like `@gaQw6zD4pHrg8zmrqku24zTSAINhRg=.ed25519` this function would return `ed25519`. This is useful as SSB start providing features for different encryption methods and cyphers.
+
 ### loadOrCreateSync (filename)
 
 Load a file containing the your private key. the file will also
@@ -92,6 +98,13 @@ with [private-box](https://github.com/auditdrivencrypto/private-box)
 
 decrypt a message encrypted with `box`. If the `boxed` successfully decrypted,
 the parsed JSON is returned, if not, `undefined` is returned.
+
+### unboxKey (boxed, keys)
+TODO: Needs more info.
+
+### unboxBody (boxed, key)
+decrypt a message. 
+TODO: fill this with extra info.
 
 ### LICENSE
 


### PR DESCRIPTION
There are more exported functions in the module than the README shows. I've tried to add the missing documentation for them but couldn't because I don't know crypto/sodium stuff. The roadblock is that the missing methods are little wrappers around `private-box` which unfortunately is out of sync with NPM. The version of that module on GH doesn't contain the stuff called by `ssb-keys`. Digging deeper into `node_modules`, I can see that these `private-box` functions are just wrappers around `libsodium` functions which I couldn't find documentation for. Kinda need help filling these last two methods in the README (they are tagged with `TODO:`).