### PR TITLE
cache curve key when decrypting, makes rebuilding indexing 15% faster.

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,8 @@ exports.unboxBody = function (boxed, key) {
 exports.unbox = function (boxed, keys) {
   boxed = u.toBuffer(boxed)
 
-  var sk = keys._sk = keys._sk || sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
+  var sk = keys._exchangeKey || sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
+  if(keys.private) keys._exchangeKey = sk //if keys is an object, cache the curve key.
   try {
     var msg = pb.multibox_open(boxed, sk)
     return JSON.parse(''+msg)

--- a/index.js
+++ b/index.js
@@ -169,11 +169,10 @@ exports.unboxBody = function (boxed, key) {
 exports.unbox = function (boxed, keys) {
   boxed = u.toBuffer(boxed)
 
+  var sk = keys._sk = keys._sk || sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
   try {
-    var sk = sodium.crypto_sign_ed25519_sk_to_curve25519(u.toBuffer(keys.private || keys))
     var msg = pb.multibox_open(boxed, sk)
     return JSON.parse(''+msg)
   } catch (_) { }
   return
 }
-


### PR DESCRIPTION
@keks and I discovered this simple change improves index building perf by 15% (on my laptop)

asymmetric operations are about 60 times more expensive than symmetric operations, and we do two of them, but this one is cachable.

@arj03 @staltz 