### PR TITLE
Use feed types

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ in the below methods, `keys` is an object of the following form:
 
 ``` js
 {
-  "curve": "ed25519",
+  "feedType": "ed25519",
   "public": "<base64_public_key>.ed25519",
   "private": "<base64_private_key>.ed25519",
   "id": "@<base64_public_key>.ed25519"
@@ -56,8 +56,8 @@ Comment lines are prefixed with `#` after removing them the result is valid JSON
 ### hash (data, encoding) => id
 Returns the sha256 hash of a given data. If encoding is not provided then it is assumed to be _binary_.
 
-### getTag (ssb_id) => tag
-The SSB ids contain a tag at the end. This function returns it.
+### getFeedType (ssbId) => feedType
+Each SSB ID contains a feed type at the end. This function returns it.
 So if you have a string like `@gaQw6zD4pHrg8zmrqku24zTSAINhRg=.ed25519` this function would return `ed25519`.
 This is useful as SSB start providing features for different encryption methods and cyphers.
 
@@ -85,13 +85,15 @@ If a sync file access method is not available, `loadOrCreate` can be called with
 callback. that callback will be called with `cb(null, keys)`. If loading
 the keys errored, new keys are created.
 
-### generate(curve, seed) => keys
+### generate(feedType, seed) => keys
 
 generate a key, with optional seed.
-curve defaults to `ed25519` (and no other type is currently supported)
+feed type defaults to `ed25519` (and no other type is currently supported)
 seed should be a 32 byte buffer.
 
 `keys` is an object as described in [`keys`](#keys) section.
+
+New feed types can be added with `ssbKeys.use()`.
 
 ### signObj(keys, hmac_key?, obj)
 
@@ -144,6 +146,10 @@ symmetrically encrypt an object with `key` (a buffer)
 ### secretUnbox (boxed, key) => obj
 
 symmetrically decrypt an object with `key` (a buffer)
+
+### use(feedTypeName, { generate, sign, verify }) => ssbKeys
+
+add new feed type to be used with `ssbKeys.generate()`
 
 ### LICENSE
 

--- a/index.js
+++ b/index.js
@@ -28,9 +28,6 @@ function isObject (o) {
   return 'object' === typeof o
 }
 
-function isFunction (f) {
-  return 'function' === typeof f
-}
 
 function isString(s) {
   return 'string' === typeof s
@@ -163,7 +160,9 @@ exports.unboxBody = function (boxed, key) {
   var msg = pb.multibox_open_body(boxed, key)
   try {
     return JSON.parse(''+msg)
-  } catch (_) { }
+  } catch (_) {
+    return undefined
+  }
 }
 
 exports.unbox = function (boxed, keys) {
@@ -174,8 +173,9 @@ exports.unbox = function (boxed, keys) {
   try {
     var msg = pb.multibox_open(boxed, sk)
     return JSON.parse(''+msg)
-  } catch (_) { }
-  return
+  } catch (_) {
+    return undefined
+  }
 }
 
 exports.secretBox = function secretBox (data, key) {

--- a/local-storage.js
+++ b/local-storage.js
@@ -1,5 +1,4 @@
 'use strict'
-var u = require('./util')
 
 function isFunction (f) {
   return 'function' == typeof f

--- a/local-storage.js
+++ b/local-storage.js
@@ -6,8 +6,8 @@ function isFunction (f) {
 
 module.exports = function (generate) {
 
-  function create (filename, curve, legacy) {
-    var keys = generate(curve, legacy)
+  function create (filename, feedType, legacy) {
+    var keys = generate(feedType, legacy)
     localStorage[filename] = JSON.stringify(keys)
     return keys
   }
@@ -18,12 +18,12 @@ module.exports = function (generate) {
 
   return {
     createSync: create,
-    create: function(filename, curve, legacy, cb) {
+    create: function(filename, feedType, legacy, cb) {
       if(isFunction(legacy))
         cb = legacy, legacy = null
-      if(isFunction(curve))
-        cb = curve, curve = null
-      cb(null, create(filename, curve, legacy))
+      if(isFunction(feedType))
+        cb = feedType, feedType = null
+      cb(null, create(filename, feedType, legacy))
     },
     loadSync: load,
     load: function (filename, cb) {

--- a/sodium.js
+++ b/sodium.js
@@ -2,15 +2,12 @@
 var sodium = require('chloride')
 
 module.exports = {
-
-  curves: ['ed25519'],
-
   generate: function (seed) {
     if(!seed) sodium.randombytes(seed = new Buffer(32))
 
     var keys = seed ? sodium.crypto_sign_seed_keypair(seed) : sodium.crypto_sign_keypair()
     return {
-      curve: 'ed25519',
+      feedType: 'ed25519',
       public: keys.publicKey,
 
       //so that this works with either sodium
@@ -18,15 +15,12 @@ module.exports = {
       private: keys.privateKey || keys.secretKey
     }
   },
-
   sign: function (privateKey, message) {
     return sodium.crypto_sign_detached(message, privateKey)
   },
-
   verify: function (publicKey, sig, message) {
     return sodium.crypto_sign_verify_detached(sig, message, publicKey)
   }
-
 }
 
 

--- a/storage.js
+++ b/storage.js
@@ -78,14 +78,14 @@ module.exports = function (generate) {
     return reconstructKeys(fs.readFileSync(filename, 'ascii'))
   }
 
-  exports.create = function(filename, curve, legacy, cb) {
+  exports.create = function(filename, feedType, legacy, cb) {
     if(isFunction(legacy))
       cb = legacy, legacy = null
-    if(isFunction(curve))
-      cb = curve, curve = null
+    if(isFunction(feedType))
+      cb = feedType, feedType = null
 
     filename = toFile(filename)
-    var keys = generate(curve)
+    var keys = generate(feedType)
     var keyfile = constructKeys(keys, legacy)
     mkdirp(path.dirname(filename), function (err) {
       if(err) return cb(err)
@@ -96,9 +96,9 @@ module.exports = function (generate) {
     })
   }
 
-  exports.createSync = function(filename, curve, legacy) {
+  exports.createSync = function(filename, feedType, legacy) {
     filename = toFile(filename)
-    var keys = generate(curve)
+    var keys = generate(feedType)
     var keyfile = constructKeys(keys, legacy)
     mkdirp.sync(path.dirname(filename))
     fs.writeFileSync(filename, keyfile, {mode: 0x100, flag: 'wx'})

--- a/storage.js
+++ b/storage.js
@@ -51,7 +51,7 @@ module.exports = function (generate) {
 
   function reconstructKeys(keyfile) {
     var privateKey = keyfile
-      .replace(/\s*\#[^\n]*/g, '')
+      .replace(/\s*#[^\n]*/g, '')
       .split('\n').filter(empty).join('')
 
     //if the key is in JSON format, we are good.

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -16,7 +16,6 @@ tape('box, unbox', function (t) {
 tape('return undefined for invalid content', function (t) {
 
   var alice = ssbkeys.generate()
-  var bob = ssbkeys.generate()
 
   var msg = ssbkeys.unbox('this is invalid content', alice.private)
   t.equal(msg, undefined)

--- a/test/fs.js
+++ b/test/fs.js
@@ -1,6 +1,5 @@
 var tape = require('tape')
 var ssbkeys = require('../')
-var crypto = require('crypto')
 var path = '/tmp/ssb-keys_'+Date.now()
 var fs = require('fs')
 

--- a/test/index.js
+++ b/test/index.js
@@ -108,15 +108,32 @@ tape('ed25519 id === "@" ++ pubkey', function (t) {
 
 })
 
+tape('alternative "test" feed type', function (t) {
+  const newFeedType = {
+    name: 'test',
+    object: {
+    generate: () => {
+      return {
+        name: newFeedType.name,
+        public: crypto.randomBytes(32).toString('hex'),
+        private: crypto.randomBytes(32).toString('hex')
+      }
+    },
+    sign: (privateKey, message) => message,
+    verify: () => true
+    }
+  }
 
+  ssbkeys.use(newFeedType.name, newFeedType.object)
 
+  const keys = ssbkeys.generate(newFeedType.name)
+  t.assert(keys.id.endsWith(newFeedType.name), 'using new test feed type')
 
+  const signedFoo = ssbkeys.signObj(keys, 'foo')
+  t.assert(signedFoo, 'foo', 'signature works')
 
-
-
-
-
-
-
-
+  const isValid = ssbkeys.verifyObj(keys, 'foo')
+  t.assert(isValid, true, 'verification works')
+  t.end()
+})
 

--- a/test/index.js
+++ b/test/index.js
@@ -70,18 +70,18 @@ tape('sign and verify a hmaced object javascript object', function (t) {
   hmac_key = hmac_key.toString('base64')
   hmac_key2 = hmac_key2.toString('base64')
 
-  var keys = ssbkeys.generate()
-  var sig = ssbkeys.signObj(keys.private, hmac_key, obj)
+  var otherKeys = ssbkeys.generate()
+  var otherSig = ssbkeys.signObj(otherKeys.private, hmac_key, obj)
   console.log(sig)
   t.ok(sig)
   //verify must be passed the key to correctly verify
-  t.notOk(ssbkeys.verifyObj(keys, sig))
-  t.notOk(ssbkeys.verifyObj({public: keys.public}, sig))
+  t.notOk(ssbkeys.verifyObj(otherKeys, otherSig))
+  t.notOk(ssbkeys.verifyObj({public: otherKeys.public}, otherSig))
   t.ok(ssbkeys.verifyObj(keys, hmac_key, sig))
-  t.ok(ssbkeys.verifyObj({public: keys.public}, hmac_key, sig))
+  t.ok(ssbkeys.verifyObj({public: otherKeys.public}, hmac_key, otherSig))
   //a different hmac_key fails to verify
-  t.notOk(ssbkeys.verifyObj(keys, hmac_key2, sig))
-  t.notOk(ssbkeys.verifyObj({public: keys.public}, hmac_key2, sig))
+  t.notOk(ssbkeys.verifyObj(otherKeys, hmac_key2, otherSig))
+  t.notOk(ssbkeys.verifyObj({public: otherKeys.public}, hmac_key2, otherSig))
 
   t.end()
 

--- a/util.js
+++ b/util.js
@@ -14,24 +14,24 @@ exports.hasSigil = function hasSigil (s) {
   return /^(@|%|&)/.test(s)
 }
 
-function tag (key, tag) {
-  if(!tag) throw new Error('no tag for:' + key.toString('base64'))
-  return key.toString('base64')+'.' + tag.replace(/^\./, '')
+function setFeedType (key, feedType) {
+  if(!feedType) throw new Error('no feedType for:' + key.toString('base64'))
+  return key.toString('base64')+'.' + feedType.replace(/^\./, '')
 }
 
-exports.keysToJSON = function keysToJSON(keys, curve) {
-  curve = (keys.curve || curve)
+exports.keysToJSON = function keysToJSON(keys, feedType) {
+  feedType = keys.feedType || feedType
 
-  var pub = tag(keys.public, curve)
+  var pub = setFeedType(keys.public, feedType)
   return {
-    curve: curve,
+    feedType,
     public: pub,
-    private: keys.private ? tag(keys.private, curve) : undefined,
+    private: keys.private ? setFeedType(keys.private, feedType) : undefined,
     id: '@' + pub
   }
 }
 
-exports.getTag = function getTag (string) {
+exports.getSuffix  = function (string) {
   var i = string.indexOf('.')
   return string.substring(i+1)
 }


### PR DESCRIPTION
**Breaking change.**

This replaces the concept of "tag" and "curve" with "feed type", which enables the use of experimental feed types other than Ed25519. 

Decision: What sort of compatibility should this module provide with loading older code that uses `{ curve }`? For example, it seems like when we read `~/.ssb/secret` we should maybe do some auto-detection to understand the previous property.

Super open to suggestions. :rocket: 