### PR TITLE
Rewrite secret file to warn users against copying

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -36,7 +36,7 @@ module.exports = function (generate) {
 #
 # This is your SECRET, it gives you magical powers. With your secret you can
 # sign your messages so that your friends can verify that the messages came
-# rom you. If anyone learns your secret, they can use it to impersonate you.
+# from you. If anyone learns your secret, they can use it to impersonate you.
 #
 # If you use this secret on more than one device you will create a fork and
 # your friends will stop replicating your content.
@@ -49,6 +49,7 @@ ${legacy ? keys.private : JSON.stringify(keys, null, 2)}
   }
 
   function reconstructKeys(keyfile) {
+	  console.log(keyfile)
     var privateKey = keyfile
       .replace(/\s*\#[^\n]*/g, '')
       .split('\n').filter(empty).join('')

--- a/storage.js
+++ b/storage.js
@@ -50,7 +50,6 @@ ${legacy ? keys.private : JSON.stringify(keys, null, 2)}
   }
 
   function reconstructKeys(keyfile) {
-	  console.log(keyfile)
     var privateKey = keyfile
       .replace(/\s*\#[^\n]*/g, '')
       .split('\n').filter(empty).join('')

--- a/storage.js
+++ b/storage.js
@@ -32,21 +32,20 @@ module.exports = function (generate) {
   function constructKeys(keys, legacy) {
     if(!keys) throw new Error('*must* pass in keys')
 
-    return [
-    '# this is your SECRET name.',
-    '# this name gives you magical powers.',
-    '# with it you can mark your messages so that your friends can verify',
-    '# that they really did come from you.',
-    '#',
-    '# if any one learns this name, they can use it to destroy your identity',
-    '# NEVER show this to anyone!!!',
-    '',
-    legacy ? keys.private : JSON.stringify(keys, null, 2),
-    '',
-    '# WARNING! It\'s vital that you DO NOT edit OR share your secret name',
-    '# instead, share your public name',
-    '# your public name: ' + keys.id
-    ].join('\n')
+    return `# WARNING: Do not edit, share, or use this file on two devices at once.
+#
+# This is your SECRET, it gives you magical powers. With your secret you can
+# sign your messages so that your friends can verify that the messages came
+# rom you. If anyone learns your secret, they can use it to impersonate you.
+#
+# If you use this secret on more than one device you will create a fork and
+# your friends will stop replicating your content.
+#
+${legacy ? keys.private : JSON.stringify(keys, null, 2)}
+#
+# The only part of this file that's safe to share is your public name:
+#
+#   ${keys.id}`
   }
 
   function reconstructKeys(keyfile) {

--- a/storage.js
+++ b/storage.js
@@ -32,7 +32,8 @@ module.exports = function (generate) {
   function constructKeys(keys, legacy) {
     if(!keys) throw new Error('*must* pass in keys')
 
-    return `# WARNING: Do not edit, share, or use this file on two devices at once.
+    return `# WARNING: Never show this to anyone.
+# WARNING: Never edit it or use it on multiple devices at once.
 #
 # This is your SECRET, it gives you magical powers. With your secret you can
 # sign your messages so that your friends can verify that the messages came


### PR DESCRIPTION
Problem: I keep seeing new SSB users who want same-as and decide to
experiment with copying their secret file to multiple devices at the
same time. This seems like it should work, and this sort of hacky ethos
would usually be encouraged, but it's risky and will inevitably fork the
feed.

Solution: Rewrite the secret file to move the warnings to the top,
adding a warning about copying the secret file to a second device.

Result:

```
# WARNING: Do not edit, share, or use this file on two devices at once.
#
# This is your SECRET, it gives you magical powers. With your secret you can
# sign your messages so that your friends can verify that the messages came
# rom you. If anyone learns your secret, they can use it to impersonate you.
#
# If you use this secret on more than one device you will create a fork and
# your friends will stop replicating your content.
#
{
  "curve": "ed25519",
  "public": "evXQK4uP4BkgvpZuaIsPXzfNWPkRooxD4knkYuqRdIg=.ed25519",
  "private": "H/99s8PVe9MgExXfI4uaVuHjAGdB45aB3cSgv/6cSp169dAri4/gGSC+lm5oiw9fN81Y+RGijEPiSeRi6pF0iA==.ed25519",
  "id": "@evXQK4uP4BkgvpZuaIsPXzfNWPkRooxD4knkYuqRdIg=.ed25519"
}
#
# The only part of this file that's safe to share is your public name:
#
#   @evXQK4uP4BkgvpZuaIsPXzfNWPkRooxD4knkYuqRdIg=.ed25519
```