### PR TITLE
Move optional arguments after mandatory arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,21 @@ var keys = ssbKeys.generate();
 */
 
 // hmac_key` is a shared secret between two peers used to authenticate the sent
-// data and can be an empty 32-byte Buffer:
-var hmac_key = Buffer.alloc(32);
-// Or a random Crypto buffer:
+// data and can be a random Crypto buffer:
 var hmac_key = crypto.randomBytes(32);
-// Or a 32-byte Buffer as base-64 string:
+// Or a 32-byte Base-64 string:
 var hmac_key = Buffer.from("7b6m0wZtYR0TevSgeNstWZUZam3IIG2B").toString(
   "base64"
 );
+// Or a 32-byte Buffer (read Warning):
+var hmac_key = Buffer.alloc(32);
+// WARNING: while a Buffer created with `Buffer.alloc` works as a valid
+// symmetric key for HMAC authentication, this value can be reproduced by any
+// attacker just by running the same command in any other machine.
 
 // The `hmac_key` is a fixed value that applies to _THIS_ signature and is used
 // to authenticate the data, `k` is the sender keys
-var obj = ssbKeys.signObj(k, hmac_key, { foo: "bar" });
+var obj = ssbKeys.signObj(k, { foo: "bar" }, hmac_key);
 /* obj => 
   {
     "foo": "bar",
@@ -48,7 +51,7 @@ var obj = ssbKeys.signObj(k, hmac_key, { foo: "bar" });
 */
 
 // Share your `hmac_key` with the message receiver so it can verify it.
-ssbKeys.verifyObj(k, hmac_key, obj); // => true
+ssbKeys.verifyObj(k, obj, hmac_key); // => true
 ```
 
 ## api
@@ -114,7 +117,7 @@ seed should be a 32 byte buffer.
 
 `keys` is an object as described in [`keys`](#keys) section.
 
-### signObj(keys, hmac_key?, obj)
+### signObj(keys, obj, hmac_key?)
 
 signs a javascript object, and then adds a signature property to it.
 
@@ -126,7 +129,7 @@ hmac key, it means that a signature intended for one use cannot be reused in ano
 
 The fine details of the signature format are described in the [protocol guide](https://ssbc.github.io/scuttlebutt-protocol-guide/#signature)
 
-### verifyObj(keys, hmac_key?, obj)
+### verifyObj(keys, obj, hmac_key?)
 
 verify a signed object. `hmac_key` must be the same value as passed to `signObj`.
 

--- a/test/index.js
+++ b/test/index.js
@@ -38,72 +38,208 @@ tape("sign and verify a javascript object, no hmac key", function (t) {
   t.ok(sig);
   t.ok(ssbkeys.verifyObj(keys, sig));
   t.ok(ssbkeys.verifyObj({ public: keys.public }, sig));
+
   t.end();
 });
+
+tape(
+  "sign and verify a javascript object with deprecated arguments order",
+  function (t) {
+    var obj = require("../package.json");
+
+    if (process.env.VERBOSE_TESTS) console.log(obj);
+
+    // Passing second argument as `null`.
+    var keys = ssbkeys.generate();
+    var sig = ssbkeys.signObj(keys.private, null, obj);
+    if (process.env.VERBOSE_TESTS) console.log(sig);
+    t.ok(sig);
+    t.ok(ssbkeys.verifyObj(keys, null, sig));
+    t.ok(ssbkeys.verifyObj({ public: keys.public }, null, sig));
+
+    // Passing second argument as `undefined`.
+    keys = ssbkeys.generate();
+    sig = ssbkeys.signObj(keys.private, undefined, obj);
+    if (process.env.VERBOSE_TESTS) console.log(sig);
+    t.ok(sig);
+    t.ok(ssbkeys.verifyObj(keys, undefined, sig));
+    t.ok(ssbkeys.verifyObj({ public: keys.public }, undefined, sig));
+
+    t.end();
+  }
+);
 
 tape("sign and verify a javascript object, falsy hmac key", function (t) {
   var obj = require("../package.json");
   var keys = ssbkeys.generate();
 
-  var sig1 = ssbkeys.signObj(keys.private, null, obj);
-  t.ok(ssbkeys.verifyObj(keys, null, sig1), "null hmac_key");
+  var sig1 = ssbkeys.signObj(keys.private, obj, null);
+  t.ok(ssbkeys.verifyObj(keys, sig1, null), "null hmac_key");
 
-  var sig2 = ssbkeys.signObj(keys.private, undefined, obj);
-  t.ok(ssbkeys.verifyObj(keys, undefined, sig2), "undefined hmac_key");
+  var sig2 = ssbkeys.signObj(keys.private, obj, undefined);
+  t.ok(ssbkeys.verifyObj(keys, sig2, undefined), "undefined hmac_key");
 
-  var sig3 = ssbkeys.signObj(keys.private, "", obj);
-  t.ok(ssbkeys.verifyObj(keys, "", sig3), "empty string hmac_key");
+  var sig3 = ssbkeys.signObj(keys.private, obj, "");
+  t.ok(ssbkeys.verifyObj(keys, sig3, ""), "empty string hmac_key");
 
-  var sig4 = ssbkeys.signObj(keys.private, 0, obj);
-  t.ok(ssbkeys.verifyObj(keys, 0, sig4), "zero hmac_key");
+  var sig4 = ssbkeys.signObj(keys.private, obj, 0);
+  t.ok(ssbkeys.verifyObj(keys, sig4, 0), "zero hmac_key");
 
-  var sig5 = ssbkeys.signObj(keys.private, NaN, obj);
-  t.ok(ssbkeys.verifyObj(keys, NaN, sig5), "NaN hmac_key");
+  var sig5 = ssbkeys.signObj(keys.private, obj, NaN);
+  t.ok(ssbkeys.verifyObj(keys, sig5, NaN), "NaN hmac_key");
 
   t.end();
 });
 
-//allow sign and verify to also take a separate key
-//so that we can create signatures that cannot be used in other places.
-//(i.e. testnet) avoiding chosen protocol attacks.
-tape("sign and verify a hmaced object javascript object", function (t) {
+tape(
+  "sign and verify a javascript object, falsy hmac key with deprecated arguments order",
+  function (t) {
+    var obj = require("../package.json");
+    var keys = ssbkeys.generate();
+
+    var sig1 = ssbkeys.signObj(keys.private, null, obj);
+    t.ok(ssbkeys.verifyObj(keys, null, sig1), "null hmac_key");
+
+    var sig2 = ssbkeys.signObj(keys.private, undefined, obj);
+    t.ok(ssbkeys.verifyObj(keys, undefined, sig2), "undefined hmac_key");
+
+    var sig3 = ssbkeys.signObj(keys.private, "", obj);
+    t.ok(ssbkeys.verifyObj(keys, "", sig3), "empty string hmac_key");
+
+    var sig4 = ssbkeys.signObj(keys.private, 0, obj);
+    t.ok(ssbkeys.verifyObj(keys, 0, sig4), "zero hmac_key");
+
+    var sig5 = ssbkeys.signObj(keys.private, NaN, obj);
+    t.ok(ssbkeys.verifyObj(keys, NaN, sig5), "NaN hmac_key");
+
+    t.end();
+  }
+);
+
+// Allow sign and verify to take a separate key to create signatures that cannot
+// be used in other places. (i.e., testnet) avoiding chosen protocol attacks.
+tape("sign and verify a hmaced javascript object", function (t) {
   var obj = require("../package.json");
+
+  // Assert that hmac key can be passed as a Crypto buffer.
   var hmac_key = crypto.randomBytes(32);
   var hmac_key2 = crypto.randomBytes(32);
 
   var keys = ssbkeys.generate();
-  var sig = ssbkeys.signObj(keys.private, hmac_key, obj);
+  var sig = ssbkeys.signObj(keys.private, obj, hmac_key);
   if (process.env.VERBOSE_TESTS) console.log(sig);
   t.ok(sig);
-  //verify must be passed the key to correctly verify
+
+  // Verify must be passed the key to verify correctly
   t.notOk(ssbkeys.verifyObj(keys, sig));
   t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig));
-  t.ok(ssbkeys.verifyObj(keys, hmac_key, sig));
-  t.ok(ssbkeys.verifyObj({ public: keys.public }, hmac_key, sig));
-  //a different hmac_key fails to verify
-  t.notOk(ssbkeys.verifyObj(keys, hmac_key2, sig));
-  t.notOk(ssbkeys.verifyObj({ public: keys.public }, hmac_key2, sig));
+  t.ok(ssbkeys.verifyObj(keys, sig, hmac_key));
+  t.ok(ssbkeys.verifyObj({ public: keys.public }, sig, hmac_key));
+  // A different hmac key fails to verify
+  t.notOk(ssbkeys.verifyObj(keys, sig, hmac_key2));
+  t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig, hmac_key2));
 
-  //assert that hmac_key may also be passed as base64
-
+  // Assert that hmac key can be passed as Base64 string.
   hmac_key = hmac_key.toString("base64");
   hmac_key2 = hmac_key2.toString("base64");
 
   keys = ssbkeys.generate();
-  sig = ssbkeys.signObj(keys.private, hmac_key, obj);
+  sig = ssbkeys.signObj(keys.private, obj, hmac_key);
   if (process.env.VERBOSE_TESTS) console.log(sig);
   t.ok(sig);
-  //verify must be passed the key to correctly verify
+
+  // Verify must be passed the key to verify correctly
   t.notOk(ssbkeys.verifyObj(keys, sig));
   t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig));
-  t.ok(ssbkeys.verifyObj(keys, hmac_key, sig));
-  t.ok(ssbkeys.verifyObj({ public: keys.public }, hmac_key, sig));
-  //a different hmac_key fails to verify
-  t.notOk(ssbkeys.verifyObj(keys, hmac_key2, sig));
-  t.notOk(ssbkeys.verifyObj({ public: keys.public }, hmac_key2, sig));
+  t.ok(ssbkeys.verifyObj(keys, sig, hmac_key));
+  t.ok(ssbkeys.verifyObj({ public: keys.public }, sig, hmac_key));
+  // A different hmac_key fails to verify
+  t.notOk(ssbkeys.verifyObj(keys, sig, hmac_key2));
+  t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig, hmac_key2));
+
+  // Assert that hmac key can be passed as Buffer.
+  hmac_key = Buffer.alloc(32);
+  hmac_key2 = Buffer.alloc(32, 1);
+
+  keys = ssbkeys.generate();
+  sig = ssbkeys.signObj(keys.private, obj, hmac_key);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
+  t.ok(sig);
+
+  // Verify must be passed the key to verify correctly
+  t.notOk(ssbkeys.verifyObj(keys, sig));
+  t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig));
+  t.ok(ssbkeys.verifyObj(keys, sig, hmac_key));
+  t.ok(ssbkeys.verifyObj({ public: keys.public }, sig, hmac_key));
+  // A different hmac key fails to verify
+  t.notOk(ssbkeys.verifyObj(keys, sig, hmac_key2));
+  t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig, hmac_key2));
 
   t.end();
 });
+
+tape(
+  "sign and verify a hmaced javascript object with deprecated arguments order",
+  function (t) {
+    var obj = require("../package.json");
+
+    // Assert that hmac key can be passed as a Crypto buffer.
+    var hmac_key = crypto.randomBytes(32);
+    var hmac_key2 = crypto.randomBytes(32);
+
+    var keys = ssbkeys.generate();
+    var sig = ssbkeys.signObj(keys.private, hmac_key, obj);
+    if (process.env.VERBOSE_TESTS) console.log(sig);
+    t.ok(sig);
+
+    // Verify must be passed the key to verify correctly
+    t.notOk(ssbkeys.verifyObj(keys, sig));
+    t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig));
+    t.ok(ssbkeys.verifyObj(keys, hmac_key, sig));
+    t.ok(ssbkeys.verifyObj({ public: keys.public }, hmac_key, sig));
+    // A different hmac key fails to verify
+    t.notOk(ssbkeys.verifyObj(keys, hmac_key2, sig));
+    t.notOk(ssbkeys.verifyObj({ public: keys.public }, hmac_key2, sig));
+
+    // Assert that hmac key can be passed as Base64 string.
+    hmac_key = hmac_key.toString("base64");
+    hmac_key2 = hmac_key2.toString("base64");
+
+    keys = ssbkeys.generate();
+    sig = ssbkeys.signObj(keys.private, hmac_key, obj);
+    if (process.env.VERBOSE_TESTS) console.log(sig);
+    t.ok(sig);
+
+    // Verify must be passed the key to verify correctly
+    t.notOk(ssbkeys.verifyObj(keys, sig));
+    t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig));
+    t.ok(ssbkeys.verifyObj(keys, hmac_key, sig));
+    t.ok(ssbkeys.verifyObj({ public: keys.public }, hmac_key, sig));
+    // A different hmac key fails to verify
+    t.notOk(ssbkeys.verifyObj(keys, hmac_key2, sig));
+    t.notOk(ssbkeys.verifyObj({ public: keys.public }, hmac_key2, sig));
+
+    // Assert that hmac key can be passed as Buffer.
+    hmac_key = Buffer.alloc(32);
+    hmac_key2 = Buffer.alloc(32, 1);
+
+    keys = ssbkeys.generate();
+    sig = ssbkeys.signObj(keys.private, hmac_key, obj);
+    if (process.env.VERBOSE_TESTS) console.log(sig);
+    t.ok(sig);
+
+    // Verify must be passed the key to verify correctly
+    t.notOk(ssbkeys.verifyObj(keys, sig));
+    t.notOk(ssbkeys.verifyObj({ public: keys.public }, sig));
+    t.ok(ssbkeys.verifyObj(keys, hmac_key, sig));
+    t.ok(ssbkeys.verifyObj({ public: keys.public }, hmac_key, sig));
+    // A different hmac key fails to verify
+    t.notOk(ssbkeys.verifyObj(keys, hmac_key2, sig));
+    t.notOk(ssbkeys.verifyObj({ public: keys.public }, hmac_key2, sig));
+
+    t.end();
+  }
+);
 
 tape("seeded keys, ed25519", function (t) {
   var seed = crypto.randomBytes(32);


### PR DESCRIPTION
These changes switch the position of the `obj` and `hmac_key` arguments to move the optional argument to the end of the list.
 
To accomplish this I created a parameter validation function to assert the order of the arguments keeping backward compatibility, the function also displays a deprecation warning that can be removed when we consider appropriate.

Closes issue #67.

cc/ @christianbundy 