### PR TITLE
allow generate() to return SSB URIs as keys.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,16 @@ If a sync file access method is not available, `loadOrCreate` can be called with
 callback. that callback will be called with `cb(null, keys)`. If loading
 the keys errored, new keys are created.
 
-### generate(curve, seed) => keys
+### generate(curve, seed, feedFormat) => keys
 
-generate a key, with optional seed.
-curve defaults to `ed25519` (and no other type is currently supported)
-seed should be a 32 byte buffer.
+generate a key, with optional `seed` (which should be a 32 byte buffer).
 
-`keys` is an object as described in [`keys`](#keys) section.
+`curve` defaults to `ed25519` (and no other type is currently supported)
+
+`feedFormat` can be either `classic`, `bendybutt-v1`, `gabbygrove-v1`, or `buttwoo-v1`. By default it's "classic".
+
+`keys` is an object as described in [`keys`](#keys) section. `keys.id` is an
+`@` sigil ID in the case of `classic` feed format and it's an SSB URI otherwise.
 
 ### sign(keys, hmac_key?, str)
 

--- a/index.js
+++ b/index.js
@@ -50,12 +50,12 @@ function getCurve(keys) {
 //this should return a key pair:
 // {curve: curve, public: Buffer, private: Buffer}
 
-exports.generate = function (curve, seed) {
+exports.generate = function (curve, seed, feedFormat) {
   curve = curve || "ed25519";
 
   if (!curves[curve]) throw new Error("unknown curve:" + curve);
 
-  return u.keysToJSON(curves[curve].generate(seed), curve);
+  return u.keysToJSON(curves[curve].generate(seed), curve, feedFormat);
 };
 
 //import functions for loading/saving keys from storage

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "chloride": "~2.4.1",
     "mkdirp": "~0.5.0",
-    "private-box": "~0.3.0"
+    "private-box": "~0.3.0",
+    "ssb-uri2": "^1.8.1"
   },
   "devDependencies": {
     "eslint": "^7.9.0",

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,38 @@ tape("create and load sync", function (t) {
   t.end();
 });
 
+tape("generate classic keys", function (t) {
+  var keys = ssbkeys.generate();
+  t.true(keys.id.startsWith("@"));
+  t.equals(keys.id.length, 53);
+  t.true(keys.id.endsWith(".ed25519"));
+  t.end();
+});
+
+tape("generate bendybutt-v1 keys", function (t) {
+  var keys = ssbkeys.generate(null, null, "bendybutt-v1");
+  t.true(keys.id.startsWith("ssb:feed/bendybutt-v1/"));
+  t.equals(keys.id.length, 66);
+  t.false(keys.id.endsWith(".ed25519"));
+  t.end();
+});
+
+tape("generate gabbygrove-v1 keys", function (t) {
+  var keys = ssbkeys.generate(null, null, "gabbygrove-v1");
+  t.true(keys.id.startsWith("ssb:feed/gabbygrove-v1/"));
+  t.equals(keys.id.length, 67);
+  t.false(keys.id.endsWith(".ed25519"));
+  t.end();
+});
+
+tape("generate buttwoo-v1 keys", function (t) {
+  var keys = ssbkeys.generate(null, null, "buttwoo-v1");
+  t.true(keys.id.startsWith("ssb:feed/buttwoo-v1/"));
+  t.equals(keys.id.length, 64);
+  t.false(keys.id.endsWith(".ed25519"));
+  t.end();
+});
+
 tape("sign and verify a string, no hmac key", function (t) {
   var str = "secure scuttlebutt";
   var keys = ssbkeys.generate();

--- a/util.js
+++ b/util.js
@@ -1,5 +1,6 @@
 "use strict";
 var cl = require("chloride");
+var SSBURI = require("ssb-uri2");
 
 exports.hash = function (data, enc) {
   data =
@@ -18,15 +19,27 @@ function tag(key, tag) {
   return key.toString("base64") + "." + tag.replace(/^\./, "");
 }
 
-exports.keysToJSON = function keysToJSON(keys, curve) {
+exports.keysToJSON = function keysToJSON(keys, curve, feedFormat) {
   curve = keys.curve || curve;
+  feedFormat = feedFormat || "classic";
 
   var pub = tag(keys.public, curve);
+  let id = "@" + pub;
+  if (
+    feedFormat === "bendybutt-v1" ||
+    feedFormat === "buttwoo-v1" ||
+    feedFormat === "gabbygrove-v1"
+  ) {
+    const classicUri = SSBURI.fromFeedSigil(id);
+    const { type, data } = SSBURI.decompose(classicUri);
+    id = SSBURI.compose({ type, format: feedFormat, data });
+  }
+
   return {
     curve: curve,
     public: pub,
     private: keys.private ? tag(keys.private, curve) : undefined,
-    id: "@" + pub,
+    id,
   };
 };
 


### PR DESCRIPTION
**Context:** we're introducing new feed formats in ssb-db2, but to generate the keys for those feed formats, ...

**Problem:** we're calling `generate()` and then mutating the return value `keys` such that `keys.id` is an SSB URI for the corresponding feed type. Sad example: https://github.com/ssbc/ssb-db2/blob/f976aac9a4bd4ee804b9f4cd24511dec52cb5d9d/test/basic.js#L372-L376

**Solution:** this PR allows you to pass an argument to `generate()` informing it of which feed format this key is for, which then automatically determines what the `keys.id` should be.