### PR TITLE
allow generate() seed arg to be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ the keys errored, new keys are created.
 
 ### generate(curve, seed, feedFormat) => keys
 
-generate a key, with optional `seed` (which should be a 32 byte buffer).
+generate a key, with optional `seed` (which should be a 32 byte buffer, but
+can be a string of any length which is then converted to a 32 byte buffer).
 
 `curve` defaults to `ed25519` (and no other type is currently supported)
 

--- a/sodium.js
+++ b/sodium.js
@@ -5,6 +5,11 @@ module.exports = {
   curves: ["ed25519"],
 
   generate: function (seed) {
+    if (seed && typeof seed === "string") {
+      const buf = Buffer.alloc(32);
+      Buffer.from(seed.substring(0, 32), "ascii").copy(buf);
+      seed = buf;
+    }
     if (!seed) sodium.randombytes((seed = Buffer.alloc(32)));
 
     var keys = seed

--- a/sodium.js
+++ b/sodium.js
@@ -7,7 +7,7 @@ module.exports = {
   generate: function (seed) {
     if (seed && typeof seed === "string") {
       const buf = Buffer.alloc(32);
-      Buffer.from(seed.substring(0, 32), "ascii").copy(buf);
+      Buffer.from(seed.substring(0, 32), "utf-8").copy(buf);
       seed = buf;
     }
     if (!seed) sodium.randombytes((seed = Buffer.alloc(32)));

--- a/test/index.js
+++ b/test/index.js
@@ -187,6 +187,21 @@ tape("seeded keys, ed25519", function (t) {
   t.end();
 });
 
+tape("seeded keys with strings, ed25519", function (t) {
+  var k1 = ssbkeys.generate("ed25519", "foo");
+  var k2 = ssbkeys.generate("ed25519", "f" + "oo");
+  t.deepEqual(k1, k2);
+
+  // String lengths over 32 are truncated
+  var veryLongString = "bar".repeat(1000);
+  var longString = "bar".repeat(11);
+  var k3 = ssbkeys.generate("ed25519", veryLongString);
+  var k4 = ssbkeys.generate("ed25519", longString);
+  t.deepEqual(k3, k4);
+
+  t.end();
+});
+
 tape('ed25519 id === "@" ++ pubkey', function (t) {
   var keys = ssbkeys.generate("ed25519");
   t.equal(keys.id, "@" + keys.public);


### PR DESCRIPTION
**Context:** For testing, it's worth using deterministic keys, but the API for passing a `seed` is a bit annoying because you have to craft a buffer yourself and it has to be 32 bytes long.

**Solution:** this PR allows the `seed` argument of `generate(curve, seed, feedFormat)` to be a string, which is then used to produce a 32-byte seed buffer regardless of the size of the seed string.